### PR TITLE
Enable inclusion of custom apache config file in Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,9 @@ FROM httpd:2.4
 # move our website into the image
 COPY ./htdocs/ /usr/local/apache2/htdocs/
 
+# custom httpd.conf
+# RUN mv /usr/local/apache2/conf/httpd.conf /usr/local/apache2/conf/httpd.conf.orig
+# COPY ./httpd.conf.espa /usr/local/apache2/conf/httpd.conf
+
 # set a terminal for convienience when logging in
 RUN export TERM=xterm

--- a/bin/run_daemon.sh
+++ b/bin/run_daemon.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 
-cd ../
+if [ ! -f Dockerfile ]
+  then
+    echo "Dockerfile not found, moving up a directory.."
+    cd ../
+    if [ ! -f Dockerfile ]
+      then
+        echo "Dockerfile not found. This script should"
+        echo "be called as bin/run_daemon.sh or ./run_daemon.sh"
+        echo "from the espa-website project folder"
+        echo "exiting..." 
+        exit 1
+    fi
+fi 
+
+if [ -f httpd.conf.espa ]
+  then
+    echo "custom Apache config found, enabling in Dockerfile.."
+    sed -i "s/^# RUN mv/RUN mv/g" Dockerfile
+    sed -i "s/^# COPY/COPY/g" Dockerfile
+fi
 
 echo "Building image..."
 docker build -t espa-apache2 .


### PR DESCRIPTION
The Docker framework doesn't allow conditionals for managing which
functions get run when building an image, so this is managed by
putting that logic in a wrapper script which builds the image, and
then launches the container
